### PR TITLE
feat: Add PyPI publishing workflow and set version to 0.1.0

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,27 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/kodeagent
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@v1.9.0

--- a/README.md
+++ b/README.md
@@ -151,6 +151,26 @@ Gemini and E2B API keys should be set in the `.env` file for integration tests t
 A [Kaggle notebook](https://www.kaggle.com/code/barunsaha/kodeagent-benchmark/) for benchmarking KodeAgent is also available.
 
 
+## 🚀 Publishing to PyPI
+
+This project uses [Trusted Publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/) to automatically publish to PyPI when a new release is created on GitHub. To set this up, follow these steps:
+
+1.  **Configure Trusted Publisher on PyPI:**
+    *   Log in to your PyPI account and go to the "Publishing" page for the `kodeagent` package.
+    *   Add a new "Trusted Publisher" with the following settings:
+        *   **Owner:** The GitHub organization or username that owns the repository (e.g., `barun-saha`).
+        *   **Repository name:** `kodeagent`
+        *   **Workflow name:** `publish-to-pypi.yml`
+
+2.  **Create a New Release on GitHub:**
+    *   Go to the "Releases" page in your GitHub repository and click "Draft a new release".
+    *   Create a new tag for the release (e.g., `v0.0.1`).
+    *   Add a title and description for the release.
+    *   Click "Publish release".
+
+Once the release is published, the GitHub Actions workflow will automatically build the package and upload it to PyPI.
+
+
 ## 🗺️ Roadmap & Contributions
 
 To be updated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,12 @@ classifiers = [
 ]
 dynamic = ["dependencies"]
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,0 @@
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup(
-        package_dir={"": "src"},
-        packages=["kodeagent"],
-        include_package_data=True,
-    )


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically publish the `kodeagent` package to PyPI when a new release is created.

Also updates the `pyproject.toml` file to be compliant with modern packaging standards and removes the legacy `setup.py` file.

Finally, it updates the `README.md` with instructions on how to configure Trusted Publishing on PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guide for publishing to PyPI using Trusted Publishing workflow with configuration instructions.

* **Chores**
  * Updated build system configuration for improved package discovery and dependency management.
  * Added automated workflow for publishing package releases to PyPI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->