### PR TITLE
feat: enable providing chat history when running any task (mutually exclusive to recurrent mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Use KodeAgent because it offers:
 Also, here are a few reasons why you shouldn't use KodeAgent:
 
 - KodeAgent is actively evolving, meaning some aspects may change.
-- You want to use some of the well-known frameworks.
-- You need a full-fledged platform with built-in long-term, persistent memory management.
+- You want to use some of the well-known frameworks or task-specific agents.
+- You need a full-fledged platform with built-in **automated** long-term, persistent memory management (KodeAgent supports manual state injection, but does not provide a persistence layer).
 
 
 ## 🚀 Quick Start
@@ -149,9 +149,12 @@ async for response in agent.run(
 
 Check out the [CSVAnalysisAgent documentation](https://kodeagent.readthedocs.io/en/latest/specialized_agents.html) for more details.
 
-### Memory(less)
+## 🧠 Memory and State Management
 
-By default, any agent in KodeAgent is **memoryless** across tasks—each task begins with no prior context, a clean slate. To enable context from the previous task (only), use **Recurrent Mode**:
+By default, any agent in KodeAgent is **memoryless** across tasks—each task begins with a clean slate. You have two ways to manage state across runs:
+
+#### 1. Recurrent Mode (Single-Task Context)
+For simple follow-up tasks within the same session, use **Recurrent Mode**. This automatically appends the description and result of the *immediately preceding* task to the current context:
 
 ```python
 # Enable recurrent mode to leverage context from the previous run
@@ -159,9 +162,21 @@ async for response in agent.run('Double the previous result', recurrent_mode=Tru
     print_response(response)
 ```
 
-This will copy the previous task's description & result into the current task's context.
+#### 2. Chat History Injection (Full Session Context)
+For multi-session persistence or complex state management, you can manually inject an existing OpenAI-compliant **Chat History**. This allows you to resume conversations from external storage or database:
 
-For more examples, including how to provide files as inputs, see the [examples.py](src/kodeagent/examples.py) module and [API documentation](https://kodeagent.readthedocs.io/en/latest/usage.html).
+```python
+history = [
+    {"role": "user", "content": "What is 5 + 5?"},
+    {"role": "assistant", "content": "10.0"}
+]
+
+# Resume with full external context
+async for response in agent.run('Now add 20 to that', chat_history=history):
+    print_response(response)
+```
+
+For more examples, see the [examples.py](src/kodeagent/examples.py) module and [API documentation](https://kodeagent.readthedocs.io/en/latest/usage.html).
 
 
 ### API Configuration

--- a/README.md
+++ b/README.md
@@ -149,11 +149,12 @@ async for response in agent.run(
 
 Check out the [CSVAnalysisAgent documentation](https://kodeagent.readthedocs.io/en/latest/specialized_agents.html) for more details.
 
+
 ## 🧠 Memory and State Management
 
 By default, any agent in KodeAgent is **memoryless** across tasks—each task begins with a clean slate. You have two ways to manage state across runs:
 
-#### 1. Recurrent Mode (Single-Task Context)
+### 1. Recurrent Mode (Single-Task Context)
 For simple follow-up tasks within the same session, use **Recurrent Mode**. This automatically appends the description and result of the *immediately preceding* task to the current context:
 
 ```python
@@ -162,7 +163,7 @@ async for response in agent.run('Double the previous result', recurrent_mode=Tru
     print_response(response)
 ```
 
-#### 2. Chat History Injection (Full Session Context)
+### 2. Chat History Injection (Full Session Context)
 For multi-session persistence or complex state management, you can manually inject an existing OpenAI-compliant **Chat History**. This allows you to resume conversations from external storage or database:
 
 ```python

--- a/docs/generated/kodeagent.agents.csv_agent.CSVAnalysisAgent.rst
+++ b/docs/generated/kodeagent.agents.csv_agent.CSVAnalysisAgent.rst
@@ -56,8 +56,8 @@
       ~CSVAnalysisAgent.task
       ~CSVAnalysisAgent.tracing_type
       ~CSVAnalysisAgent.work_dir
-      ~CSVAnalysisAgent.tools
       ~CSVAnalysisAgent.model_name
+      ~CSVAnalysisAgent.tools
       ~CSVAnalysisAgent.litellm_params
       ~CSVAnalysisAgent.id
       ~CSVAnalysisAgent.tool_name_to_func

--- a/docs/generated/kodeagent.fca.Task.rst
+++ b/docs/generated/kodeagent.fca.Task.rst
@@ -1,4 +1,4 @@
-kodeagent.fca.Task
+﻿kodeagent.fca.Task
 ==================
 
 .. currentmodule:: kodeagent.fca
@@ -14,6 +14,29 @@ kodeagent.fca.Task
    .. autosummary::
    
       ~Task.__init__
+      ~Task.construct
+      ~Task.copy
+      ~Task.dict
+      ~Task.from_orm
+      ~Task.json
+      ~Task.model_construct
+      ~Task.model_copy
+      ~Task.model_dump
+      ~Task.model_dump_json
+      ~Task.model_json_schema
+      ~Task.model_parametrized_name
+      ~Task.model_post_init
+      ~Task.model_rebuild
+      ~Task.model_validate
+      ~Task.model_validate_json
+      ~Task.model_validate_strings
+      ~Task.parse_file
+      ~Task.parse_obj
+      ~Task.parse_raw
+      ~Task.schema
+      ~Task.schema_json
+      ~Task.update_forward_refs
+      ~Task.validate
    
    
 
@@ -23,10 +46,24 @@ kodeagent.fca.Task
 
    .. autosummary::
    
-      ~Task.files
+      ~Task.model_computed_fields
+      ~Task.model_config
+      ~Task.model_extra
+      ~Task.model_fields
+      ~Task.model_fields_set
       ~Task.id
       ~Task.description
+      ~Task.files
       ~Task.result
+      ~Task.is_finished
+      ~Task.is_error
+      ~Task.output_files
       ~Task.steps_taken
+      ~Task.total_llm_calls
+      ~Task.total_prompt_tokens
+      ~Task.total_completion_tokens
+      ~Task.total_tokens
+      ~Task.total_cost
+      ~Task.usage_by_component
    
    

--- a/docs/generated/kodeagent.fca.rst
+++ b/docs/generated/kodeagent.fca.rst
@@ -18,11 +18,7 @@
    
 
    
-   AgentResponse
-   
    FunctionCallingAgent
-   
-   Task
    
 
 .. automodule:: kodeagent.fca

--- a/docs/generated/kodeagent.kodeagent.CodeActAgent.rst
+++ b/docs/generated/kodeagent.kodeagent.CodeActAgent.rst
@@ -61,8 +61,8 @@
       ~CodeActAgent.timeout
       ~CodeActAgent.tracing_type
       ~CodeActAgent.work_dir
-      ~CodeActAgent.tools
       ~CodeActAgent.model_name
+      ~CodeActAgent.tools
       ~CodeActAgent.litellm_params
       ~CodeActAgent.id
       ~CodeActAgent.tool_name_to_func

--- a/docs/generated/kodeagent.kodeagent.ReActAgent.rst
+++ b/docs/generated/kodeagent.kodeagent.ReActAgent.rst
@@ -56,8 +56,8 @@
       ~ReActAgent.task
       ~ReActAgent.tracing_type
       ~ReActAgent.work_dir
-      ~ReActAgent.tools
       ~ReActAgent.model_name
+      ~ReActAgent.tools
       ~ReActAgent.litellm_params
       ~ReActAgent.id
       ~ReActAgent.tool_name_to_func

--- a/docs/generated/kodeagent.kutils.rst
+++ b/docs/generated/kodeagent.kutils.rst
@@ -34,6 +34,8 @@
    
    read_prompt
    
+   validate_chat_history
+   
 
    
 

--- a/docs/generated/kodeagent.kutils.validate_chat_history.rst
+++ b/docs/generated/kodeagent.kutils.validate_chat_history.rst
@@ -1,0 +1,6 @@
+kodeagent.kutils.validate\_chat\_history
+========================================
+
+.. currentmodule:: kodeagent.kutils
+
+.. autofunction:: validate_chat_history

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -151,11 +151,15 @@ print(agent.current_plan)
 ```
 
 
-## Recurrent Mode (Memory)
+## Memory and State Management
 
-KodeAgent is designed to be minimalistic and **stateless** by default. Each call to `run()` is independent, and the agent does not retain conversation history or results from previous tasks.
+KodeAgent is designed to be minimalistic and **memoryless across tasks** by default. Each call to `run()` is independent, and the agent does not retain conversation history or results from previous tasks.
 
-However, you can enable **Recurrent Mode** by passing `recurrent_mode=True` to the `run()` method. When enabled, the current task description is automatically augmented with context from the *immediately preceding* task executed by that agent instance.
+However, you have two ways to manage state across runs if needed.
+
+### 1. Recurrent Mode (Single-Task Context)
+
+You can enable **Recurrent Mode** by passing `recurrent_mode=True` to the `run()` method. When enabled, the current task description is automatically augmented with context from the *immediately preceding* task executed by that agent instance.
 
 ### What is Augmented?
 
@@ -202,6 +206,36 @@ When using tracing (Langfuse or LangSmith), the augmented task description is ca
 > **ⓘ NOTE**
 >
 > While `langfuse` is included with KodeAgent by default, `langsmith` is not and must be installed separately using `pip install langsmith`.
+
+
+### 2. Chat History Injection (Full Session Context)
+
+For more complex state management or multi-session persistence, you can manually provide an existing OpenAI-compliant **Chat History** to the `run()` method. This allows you to "resume" an agent from a previously saved state. For example, an application that uses KodeAgent to solve tasks can save the chat history to a database or external log, and then use it to resume the agent from that state. Here is an example:
+
+```python
+# A previously saved chat history
+history = [
+    {"role": "user", "content": "What is 5 + 5?"},
+    {"role": "assistant", "content": "10.0"}
+]
+
+# Inject the history to continue the conversation in a new task
+async for response in agent.run('Now add 20 to that result', chat_history=history):
+    print_response(response, only_final=True)
+```
+
+The injected chat history may also include tool calls and tool results from previous tasks. The agent will use this information to continue the conversation in a seamless manner. However, any incorrect tool call sequences in the provided `chat_history` will raise errors.
+
+### Validation
+KodeAgent performs stringent validation on the provided `chat_history` to ensure it is compliant with OpenAI's API structure:
+- **Roles**: Must be one of `system`, `user`, `assistant`, or `tool`.
+- **System Message**: Only one system message is allowed, and it must be at index 0. If you don't provide one, the agent's default system prompt will be prepended automatically.
+- **Tool Integrity**: Every `tool` message must refer to a valid `tool_call_id` from a preceding `assistant` message.
+- **Pending Resolution**: You cannot inject a history that ends with unresolved tool calls (i.e., an assistant message with `tool_calls` that does not have corresponding `tool` results).
+
+> **ⓘ NOTE**
+>
+> `chat_history` and `recurrent_mode` are mutually exclusive. Attempting to provide both will raise a `ValueError`.
 
 
 ## Streaming Responses

--- a/src/kodeagent/_version.py
+++ b/src/kodeagent/_version.py
@@ -7,4 +7,4 @@ Update the __version__ string here BEFORE making a release on GitHub.
 # minor: New features, backward compatible
 # major: Breaking changes, API changes
 
-__version__ = '0.13.0'
+__version__ = '0.14.0'

--- a/src/kodeagent/examples.py
+++ b/src/kodeagent/examples.py
@@ -148,6 +148,31 @@ async def _run_examples_async(
         ):
             print_response(response, only_final=True)
 
+        print('\n\nDemonstrating Chat History Injection:\n')
+        # Initial history from a previous session or external storage
+        history = [
+            {'role': 'user', 'content': 'What is 5 + 5?'},
+            {
+                'role': 'assistant',
+                'content': 'I will calculate 5 + 5.',
+                'tool_calls': [
+                    {
+                        'id': 'call_123',
+                        'type': 'function',
+                        'function': {
+                            'name': 'calculator',
+                            'arguments': '{"expression": "5 + 5"}',
+                        },
+                    }
+                ],
+            },
+            {'role': 'tool', 'tool_call_id': 'call_123', 'name': 'calculator', 'content': '10.0'},
+            {'role': 'assistant', 'content': 'The result is 10.0.'},
+        ]
+        print('Resuming with existing history...')
+        async for response in agent.run('Now add 20 to that result', chat_history=history):
+            print_response(response, only_final=True)
+
     atype = agent_type.lower()
 
     if atype == 'codeact':
@@ -169,7 +194,7 @@ async def run_examples(
 ) -> None:
     """Run KodeAgent with a list of pre-defined tasks and the choice of agent.
     Some of the tasks include files or URLs.
-    The last task is run with `recurrent_mode=True` to demonstrate that feature.
+    The demo includes demonstrations of `recurrent_mode` and `chat_history` injection.
 
     Args:
         agent_type: Which agent to run; one of `react`, `codeact`, or `fca`.
@@ -182,7 +207,7 @@ async def run_examples(
 if __name__ == '__main__':
     os.environ['PYTHONUTF8'] = '1'
     # Simple CLI handling for demo purposes
-    selected_atype = 'react'
+    selected_atype = 'fca'
 
     if len(sys.argv) > 1:
         for arg in sys.argv[1:]:

--- a/src/kodeagent/examples.py
+++ b/src/kodeagent/examples.py
@@ -207,7 +207,7 @@ async def run_examples(
 if __name__ == '__main__':
     os.environ['PYTHONUTF8'] = '1'
     # Simple CLI handling for demo purposes
-    selected_atype = 'fca'
+    selected_atype = 'react'
 
     if len(sys.argv) > 1:
         for arg in sys.argv[1:]:

--- a/src/kodeagent/fca.py
+++ b/src/kodeagent/fca.py
@@ -4,6 +4,7 @@ reproduced here to keep this module self-contained and optimized.
 """
 
 import asyncio
+import copy
 import json
 import logging
 import re
@@ -353,6 +354,7 @@ class FunctionCallingAgent:
         task_id: str | None = None,
         use_planning: bool = True,
         recurrent_mode: bool = False,
+        chat_history: list[dict] | None = None,
     ) -> None:
         """Initialize the running of a task.
 
@@ -362,7 +364,10 @@ class FunctionCallingAgent:
             task_id: Optional task ID.
             use_planning: If True, generate a simple plan at the beginning of the task.
             recurrent_mode: If True, the agent will continue to run on the same task
-             until it decides to stop, allowing for more dynamic interactions.
+                until it decides to stop, allowing for more dynamic interactions.
+            chat_history: Optional pre-built OpenAI-compliant chat history to inject
+                as the base context. When provided, the new task message is appended
+                at the end of this history. Mutually exclusive with ``recurrent_mode``.
         """
         if not task_desc or not task_desc.strip():
             raise ValueError('Task description cannot be empty!')
@@ -384,10 +389,23 @@ class FunctionCallingAgent:
         if task_id is not None:
             task_kwargs['id'] = task_id
         self.task = Task(**task_kwargs)
-        self.chat_history = [
-            {'role': 'system', 'content': self.system_prompt},
-            *user_task_msg,
-        ]
+
+        if chat_history is not None:
+            # Validate and deep-copy the injected history
+            ku.validate_chat_history(
+                chat_history,
+                tool_names=set(self.tool_map.keys()),
+            )
+            base_history = copy.deepcopy(chat_history)
+            # Ensure a system message is present at index 0
+            if not (base_history and base_history[0].get('role') == 'system'):
+                base_history.insert(0, {'role': 'system', 'content': self.system_prompt})
+            self.chat_history = base_history + list(user_task_msg)
+        else:
+            self.chat_history = [
+                {'role': 'system', 'content': self.system_prompt},
+                *user_task_msg,
+            ]
 
         if use_planning:
             planner = Planner(
@@ -479,6 +497,7 @@ class FunctionCallingAgent:
         use_planning: bool = True,
         recurrent_mode: bool = False,
         loop_threshold: int = 3,
+        chat_history: list[dict] | None = None,
     ) -> AsyncIterator[AgentResponse]:
         """Main loop for the agent to process input and execute tools until finished.
         If an SLM call fails, it tries up to 3 times with a backoff before terminating.
@@ -494,13 +513,29 @@ class FunctionCallingAgent:
             Note: not invoked after a hard-stop due to repeated SLM failures.
             use_planning: If True, generate a simple plan at the beginning of the task.
             recurrent_mode: If True, the agent continues from the previous task result,
-            allowing for multi-turn workflows.
+            allowing for multi-turn workflows. Mutually exclusive with ``chat_history``.
             loop_threshold: Number of consecutive same tool calls before triggering loop detection.
+            chat_history: Optional pre-built OpenAI-compliant history to inject as the
+            base context for this run. The new task message is appended at the end.
+            Mutually exclusive with ``recurrent_mode``.
 
         Yields:
             AgentResponse: Streaming log, step, and final responses.
+
+        Raises:
+            ValueError: If both ``recurrent_mode`` and ``chat_history`` are set, or if
+                the provided history fails OpenAI compliance validation.
         """
-        await self._run_init(task, files, use_planning=use_planning, recurrent_mode=recurrent_mode)
+        if recurrent_mode and chat_history is not None:
+            raise ValueError(
+                'recurrent_mode and chat_history are mutually exclusive. '
+                'Use one or the other, not both.'
+            )
+
+        await self._run_init(
+            task, files, use_planning=use_planning, recurrent_mode=recurrent_mode,
+            chat_history=chat_history,
+        )
 
         n_turns = 0
         self.final_answer_found = False

--- a/src/kodeagent/kodeagent.py
+++ b/src/kodeagent/kodeagent.py
@@ -3,6 +3,7 @@ Implements ReAct and CodeAct agents, supported by Planner and Observer.
 """
 
 import asyncio
+import copy
 import inspect
 import json
 import random
@@ -110,6 +111,7 @@ class Agent(ABC):
 
     _history_formatter: HistoryFormatter | None = field(init=False, default=None)
     _tool_descriptions_cache: dict[frozenset[str], str] = field(init=False, default_factory=dict)
+    _history_injected: bool = field(init=False, default=False)
 
     response_format_class: ClassVar[type[pyd.BaseModel]] = ChatMessage
     HISTORY_TRUNCATE_CHARS: ClassVar[int] = 1000
@@ -203,7 +205,11 @@ class Agent(ABC):
         return ''.join(context_parts)
 
     def _run_init(
-        self, task: str, files: list[str] | None = None, task_id: str | None = None
+        self,
+        task: str,
+        files: list[str] | None = None,
+        task_id: str | None = None,
+        chat_history: list[dict] | None = None,
     ) -> None:
         """Initialize the running of a task by an agent.
 
@@ -211,9 +217,14 @@ class Agent(ABC):
             task: Task description.
             files: Optional files for the task.
             task_id: Optional task ID.
+            chat_history: Optional pre-built OpenAI-compliant chat history to inject.
+                When provided, this history becomes the base of ``self.chat_history``
+                (deep-copied to avoid mutating the caller's object). The new task
+                message is then appended on top during ``pre_run()``.
 
         Raises:
-            ValueError: If task is empty or files list is invalid.
+            ValueError: If task is empty, files list is invalid, or the provided
+                history fails OpenAI compliance validation.
         """
         if not task or not task.strip():
             raise ValueError('Task description cannot be empty!')
@@ -221,6 +232,16 @@ class Agent(ABC):
             raise ValueError('Task files must be a list of file paths!')
         if files and len(files) > MAX_TASK_FILES:
             raise ValueError(f'Too many files provided for the task (max {MAX_TASK_FILES})!')
+
+        # Validate and apply injected history
+        if chat_history is not None:
+            ku.validate_chat_history(chat_history, tool_names=self.tool_names)
+            self.chat_history = copy.deepcopy(chat_history)
+            # Track where injected context ends so new task messages are appended after
+            self.msg_idx_of_new_task = len(self.chat_history)
+            self._history_injected = True
+        else:
+            self._history_injected = False
 
         self.task = Task(description=task, files=files)
         self.task_output_files = []
@@ -323,6 +344,7 @@ class Agent(ABC):
         max_iterations: int | None = None,
         recurrent_mode: bool = False,
         summarize_progress_on_failure: bool = True,
+        chat_history: list[dict] | None = None,
     ) -> AsyncIterator[AgentResponse]:
         """Execute a task using the agent.
 
@@ -331,11 +353,19 @@ class Agent(ABC):
             files: List of files associated with the task.
             task_id: Optional task ID.
             max_iterations: Optional maximum number of iterations.
-            recurrent_mode: Whether to run in recurrent mode.
+            recurrent_mode: Whether to run in recurrent mode (augments task text
+                with the previous task description and result). Mutually exclusive
+                with ``chat_history``.
             summarize_progress_on_failure: Whether to summarize progress on failure.
+            chat_history: Optional pre-built OpenAI-compliant history to inject as
+                the base context for this task run. Mutually exclusive with
+                ``recurrent_mode``.
 
         Returns:
             AsyncIterator[AgentResponse]: An iterator yielding agent responses.
+
+        Raises:
+            ValueError: If both ``recurrent_mode`` and ``chat_history`` are provided.
         """
 
     def response(
@@ -677,13 +707,25 @@ class ReActAgent(Agent):
 
     async def pre_run(self) -> AsyncIterator[AgentResponse]:
         """Perform setup before the main run loop.
-        - Initialize task and history.
+        - Initialize task and history (or ensure injected history has a system prompt).
         - Create initial plan.
 
         Returns:
             AsyncIterator[AgentResponse]: Iterator of agent responses.
         """
-        self.init_history()
+        if self._history_injected:
+            # Injected history is already in self.chat_history (deep-copied in _run_init).
+            # If it has no system message at index 0, prepend the agent's own system prompt.
+            if not (self.chat_history and self.chat_history[0].get('role') == 'system'):
+                system_content = self.system_prompt.format(
+                    persona=self.persona or '', tools=self.get_tools_description()
+                )
+                self.chat_history.insert(0, {'role': 'system', 'content': system_content})
+                # Shift the new-task index to account for the inserted system message
+                self.msg_idx_of_new_task += 1
+            self.final_answer_found = False
+        else:
+            self.init_history()
 
         yield self.response(
             rtype='log', value=f'Solving task: `{self.task.description}`', channel='run'
@@ -763,6 +805,7 @@ class ReActAgent(Agent):
         max_iterations: int | None = None,
         recurrent_mode: bool = False,
         summarize_progress_on_failure: bool = True,
+        chat_history: list[dict] | None = None,
     ) -> AsyncIterator[AgentResponse]:
         """Solve a task using ReAct's TAO loop (or CodeAct's TCO loop).
 
@@ -772,23 +815,36 @@ class ReActAgent(Agent):
             task_id: Optional task ID.
             max_iterations: Optional max iterations for the task.
             recurrent_mode: If True, augment task with previous task context.
+                Mutually exclusive with ``chat_history``.
             summarize_progress_on_failure: Whether to summarize progress if
-             the agent fails to solve the task in max iterations.
+                the agent fails to solve the task in max iterations.
+            chat_history: Optional pre-built OpenAI-compliant history to inject
+                as the base context for this run. The new task message is appended
+                on top. Mutually exclusive with ``recurrent_mode``.
 
         Returns:
             Step updates on the task and the final response.
 
         Raises:
-            ValueError: If task is empty or too many files provided.
+            ValueError: If task is empty, too many files provided, both
+                ``recurrent_mode`` and ``chat_history`` are set, or the provided
+                history fails OpenAI compliance validation.
             RetryError: If LLM calls fail after max retries.
         """
+        if recurrent_mode and chat_history is not None:
+            raise ValueError(
+                'recurrent_mode and chat_history are mutually exclusive. '
+                'Use one or the other, not both.'
+            )
+
         if recurrent_mode and self.task is not None:
             task = await self._augment_task_with_previous(task)
             logger.debug('Recurrent mode enabled: augmented task with previous context')
 
         # 1. run() calls _run_init()
-        # 2. pre_run() calls init_history() and does the logging/planning
-        self._run_init(task, files, task_id)
+        # 2. pre_run() calls init_history() (or applies injected history) and does
+        #    the logging/planning
+        self._run_init(task, files, task_id, chat_history=chat_history)
 
         # Execute pre-run hook
         async for response in self.pre_run():

--- a/src/kodeagent/kodeagent.py
+++ b/src/kodeagent/kodeagent.py
@@ -111,7 +111,6 @@ class Agent(ABC):
 
     _history_formatter: HistoryFormatter | None = field(init=False, default=None)
     _tool_descriptions_cache: dict[frozenset[str], str] = field(init=False, default_factory=dict)
-    _history_injected: bool = field(init=False, default=False)
 
     response_format_class: ClassVar[type[pyd.BaseModel]] = ChatMessage
     HISTORY_TRUNCATE_CHARS: ClassVar[int] = 1000
@@ -219,8 +218,7 @@ class Agent(ABC):
             task_id: Optional task ID.
             chat_history: Optional pre-built OpenAI-compliant chat history to inject.
                 When provided, this history becomes the base of ``self.chat_history``
-                (deep-copied to avoid mutating the caller's object). The new task
-                message is then appended on top during ``pre_run()``.
+                (deep-copied to avoid mutating the caller's object).
 
         Raises:
             ValueError: If task is empty, files list is invalid, or the provided
@@ -236,12 +234,17 @@ class Agent(ABC):
         # Validate and apply injected history
         if chat_history is not None:
             ku.validate_chat_history(chat_history, tool_names=self.tool_names)
-            self.chat_history = copy.deepcopy(chat_history)
+            base = copy.deepcopy(chat_history)
+            # If it has no system message at index 0, prepend the agent's own system prompt.
+            if not (base and base[0].get('role') == 'system'):
+                base.insert(0, {'role': 'system', 'content': self.get_system_prompt_content()})
+
+            self.chat_history = base
             # Track where injected context ends so new task messages are appended after
             self.msg_idx_of_new_task = len(self.chat_history)
-            self._history_injected = True
         else:
-            self._history_injected = False
+            self.init_history()
+            self.msg_idx_of_new_task = len(self.chat_history)
 
         self.task = Task(description=task, files=files)
         self.task_output_files = []
@@ -579,6 +582,21 @@ class Agent(ABC):
 
         return '\n'.join(segments)
 
+    def get_system_prompt_content(self) -> str:
+        """Return the formatted system prompt string for this agent.
+
+        Subclasses should override this to include additional format variables.
+
+        Returns:
+            The formatted system prompt.
+        """
+        if not self.system_prompt:
+            return ''
+
+        return self.system_prompt.format(
+            persona=self.persona or '', tools=self.get_tools_description()
+        )
+
     def clear_history(self):
         """Clear the agent's message history."""
         self.chat_history = []
@@ -680,10 +698,7 @@ class ReActAgent(Agent):
 
     def init_history(self):
         """Initialize the agent's message history with the system prompt."""
-        content = self.system_prompt.format(
-            persona=self.persona or '', tools=self.get_tools_description()
-        )
-        self.chat_history = [{'role': 'system', 'content': content}]
+        self.chat_history = [{'role': 'system', 'content': self.get_system_prompt_content()}]
         self.final_answer_found = False
 
     async def _create_initial_plan(self):
@@ -713,19 +728,7 @@ class ReActAgent(Agent):
         Returns:
             AsyncIterator[AgentResponse]: Iterator of agent responses.
         """
-        if self._history_injected:
-            # Injected history is already in self.chat_history (deep-copied in _run_init).
-            # If it has no system message at index 0, prepend the agent's own system prompt.
-            if not (self.chat_history and self.chat_history[0].get('role') == 'system'):
-                system_content = self.system_prompt.format(
-                    persona=self.persona or '', tools=self.get_tools_description()
-                )
-                self.chat_history.insert(0, {'role': 'system', 'content': system_content})
-                # Shift the new-task index to account for the inserted system message
-                self.msg_idx_of_new_task += 1
-            self.final_answer_found = False
-        else:
-            self.init_history()
+        self.final_answer_found = False
 
         yield self.response(
             rtype='log', value=f'Solving task: `{self.task.description}`', channel='run'
@@ -833,8 +836,8 @@ class ReActAgent(Agent):
         """
         if recurrent_mode and chat_history is not None:
             raise ValueError(
-                'recurrent_mode and chat_history are mutually exclusive. '
-                'Use one or the other, not both.'
+                'recurrent_mode and chat_history are mutually exclusive.'
+                ' Use one or the other, not both.'
             )
 
         if recurrent_mode and self.task is not None:
@@ -1297,13 +1300,11 @@ class ReActAgent(Agent):
                         tool_call_id = self._get_last_tool_call_id()
 
                         # Always use role='tool' for tool results
-                        self.add_to_history(
-                            {
-                                'role': 'tool',
-                                'content': str(result),
-                                'tool_call_id': tool_call_id,
-                            }
-                        )
+                        self.add_to_history({
+                            'role': 'tool',
+                            'content': str(result),
+                            'tool_call_id': tool_call_id,
+                        })
 
                         act_span.update(
                             status='success',
@@ -1345,13 +1346,11 @@ class ReActAgent(Agent):
                         tool_call_id = self._get_last_tool_call_id()
 
                         # Use role='tool' for tool errors too
-                        self.add_to_history(
-                            {
-                                'role': 'tool',
-                                'content': result,
-                                'tool_call_id': tool_call_id,
-                            }
-                        )
+                        self.add_to_history({
+                            'role': 'tool',
+                            'content': result,
+                            'tool_call_id': tool_call_id,
+                        })
                         yield self.response(
                             rtype='step',
                             value=result,
@@ -1594,15 +1593,17 @@ class CodeActAgent(ReActAgent):
             f'Could not extract valid Code or Answer from response. Text: {text[:300]}...'
         )
 
-    def init_history(self):
-        """Initialize message history with system prompt for CodeAct agent."""
-        content = self.system_prompt.format(
+    def get_system_prompt_content(self) -> str:
+        """Return the formatted system prompt string for CodeAct agent."""
+        return self.system_prompt.format(
             persona=self.persona or '',
             tools=self.get_tools_description(),
-            authorized_imports='\n'.join([f'- {imp}' for imp in self.allowed_imports]),
+            authorized_imports='\n'.join([f'- {imp}' for imp in (self.allowed_imports or [])]),
         )
-        self.chat_history = [{'role': 'system', 'content': content}]
-        self.final_answer_found = False
+
+    def init_history(self):
+        """Initialize message history with system prompt for CodeAct agent."""
+        super().init_history()
 
     async def _think(self) -> AsyncIterator[AgentResponse]:
         """Think step for CodeAct agent.

--- a/src/kodeagent/kutils.py
+++ b/src/kodeagent/kutils.py
@@ -502,6 +502,185 @@ def parse_param_descriptions(doc: str) -> dict[str, str]:
     return param_docs
 
 
+VALID_ROLES = {'system', 'user', 'assistant', 'tool'}
+
+
+def validate_chat_history(history: list[dict], tool_names: set[str] | None = None) -> None:
+    """Validate that a provided chat history is OpenAI-compliant.
+
+    Performs stringent structural and semantic checks on each message. Raises
+    ``ValueError`` with a precise description on the first problem found.
+
+    Args:
+        history: The chat history to validate. Must be a non-empty ``list[dict]``.
+        tool_names: Optional set of tool names registered on the agent. When
+            provided, tool call names not in this set emit a ``logger.warning``.
+
+    Raises:
+        ValueError: If the history fails any structural or compliance check.
+    """
+    if not isinstance(history, list):
+        raise ValueError(
+            f'chat_history must be a list[dict], got {type(history).__name__}.'
+        )
+    if not history:
+        raise ValueError('chat_history must not be empty.')
+
+    system_seen_at: int | None = None
+    requested_tool_call_ids: set[str] = set()
+
+    for idx, msg in enumerate(history):
+        if not isinstance(msg, dict):
+            raise ValueError(
+                f'chat_history[{idx}]: each message must be a dict, '
+                f'got {type(msg).__name__}.'
+            )
+
+        role = msg.get('role')
+        if role not in VALID_ROLES:
+            raise ValueError(
+                f"chat_history[{idx}]: 'role' must be one of {sorted(VALID_ROLES)}, "
+                f"got {role!r}."
+            )
+
+        # ── system message rules ──────────────────────────────────────────
+        if role == 'system':
+            if idx != 0:
+                raise ValueError(
+                    f'chat_history[{idx}]: system message must be at index 0, '
+                    f'not at index {idx}.'
+                )
+            system_seen_at = idx
+            if msg.get('content') is None:
+                raise ValueError(
+                    f"chat_history[{idx}]: system message must have a non-None 'content'."
+                )
+
+        # ── user message rules ────────────────────────────────────────────
+        elif role == 'user':
+            if msg.get('content') is None:
+                raise ValueError(
+                    f"chat_history[{idx}]: user message must have a non-None 'content'."
+                )
+
+        # ── assistant message rules ───────────────────────────────────────
+        elif role == 'assistant':
+            tool_calls = msg.get('tool_calls')
+            content = msg.get('content')
+
+            if tool_calls is None and content is None:
+                raise ValueError(
+                    f'chat_history[{idx}]: assistant message must have either '
+                    f"'content' or 'tool_calls'."
+                )
+
+            if tool_calls is not None:
+                if not isinstance(tool_calls, list):
+                    raise ValueError(
+                        f"chat_history[{idx}]: 'tool_calls' must be a list, "
+                        f'got {type(tool_calls).__name__}.'
+                    )
+                for tc_idx, tc in enumerate(tool_calls):
+                    if not isinstance(tc, dict):
+                        raise ValueError(
+                            f'chat_history[{idx}].tool_calls[{tc_idx}]: '
+                            f'each tool call must be a dict, got {type(tc).__name__}.'
+                        )
+                    tc_id = tc.get('id')
+                    if not tc_id or not isinstance(tc_id, str):
+                        raise ValueError(
+                            f'chat_history[{idx}].tool_calls[{tc_idx}]: '
+                            f"missing or empty 'id' (string required)."
+                        )
+                    
+                    # Track for subsequent tool result validation
+                    requested_tool_call_ids.add(tc_id)
+
+                    if tc.get('type') != 'function':
+                        raise ValueError(
+                            f'chat_history[{idx}].tool_calls[{tc_idx}]: '
+                            f"'type' must be 'function', got {tc.get('type')!r}."
+                        )
+                    fn = tc.get('function')
+                    if not isinstance(fn, dict):
+                        raise ValueError(
+                            f'chat_history[{idx}].tool_calls[{tc_idx}]: '
+                            f"'function' must be a dict, got {type(fn).__name__}."
+                        )
+                    fn_name = fn.get('name')
+                    if not fn_name or not isinstance(fn_name, str):
+                        raise ValueError(
+                            f'chat_history[{idx}].tool_calls[{tc_idx}]: '
+                            f"'function.name' must be a non-empty string."
+                        )
+                    if not isinstance(fn.get('arguments'), str):
+                        raise ValueError(
+                            f'chat_history[{idx}].tool_calls[{tc_idx}]: '
+                            f"'function.arguments' must be a string (JSON-encoded)."
+                        )
+                    # Warn about unknown tool names
+                    if tool_names is not None and fn_name not in tool_names:
+                        logger.warning(
+                            'chat_history[%d].tool_calls[%d]: tool name %r not registered '
+                            'on this agent (known: %s). The LLM will not re-call it.',
+                            idx,
+                            tc_idx,
+                            fn_name,
+                            sorted(tool_names),
+                        )
+
+        # ── tool result message rules ─────────────────────────────────────
+        elif role == 'tool':
+            tc_id = msg.get('tool_call_id')
+            if not tc_id or not isinstance(tc_id, str):
+                raise ValueError(
+                    f"chat_history[{idx}]: tool message missing or empty 'tool_call_id' "
+                    f'(string required).'
+                )
+            name = msg.get('name')
+            if not name or not isinstance(name, str):
+                raise ValueError(
+                    f"chat_history[{idx}]: tool message missing or empty 'name' "
+                    f'(string required).'
+                )
+            if not isinstance(msg.get('content'), str):
+                raise ValueError(
+                    f"chat_history[{idx}]: tool message 'content' must be a string, "
+                    f"got {type(msg.get('content')).__name__}."
+                )
+            # Ensure this result refers to a tool call that was actually requested
+            if tc_id not in requested_tool_call_ids:
+                raise ValueError(
+                    f"chat_history[{idx}]: tool message refers to unknown "
+                    f"tool_call_id {tc_id!r}."
+                )
+
+    # ── pending tool call check ───────────────────────────────────────────
+    # Walk backwards; if the last assistant message has tool_calls, verify
+    # that every id appears in a subsequent tool message.
+    tool_result_ids: set[str] = set()
+    for msg in reversed(history):
+        role = msg.get('role')
+        if role == 'tool':
+            tool_result_ids.add(msg.get('tool_call_id', ''))
+        elif role == 'assistant':
+            pending = msg.get('tool_calls')
+            if pending:
+                unresolved = [
+                    tc['id']
+                    for tc in pending
+                    if isinstance(tc, dict) and tc.get('id') not in tool_result_ids
+                ]
+                if unresolved:
+                    raise ValueError(
+                        f'chat_history ends with unresolved tool call(s): '
+                        f'{unresolved}. Each tool_call must have a corresponding '
+                        f"'tool' message before appending new messages."
+                    )
+            # Stop at the first assistant message from the end
+            break
+
+
 def build_tool_schema(
     fn: Callable, just_first_line: bool = False, as_text: bool = True
 ) -> dict[str, Any] | str:

--- a/tests/unit/test_history_injection.py
+++ b/tests/unit/test_history_injection.py
@@ -20,16 +20,13 @@ def test_validate_chat_history_valid(mock_agent):
     # This should not raise
     mock_agent._run_init(task="test", chat_history=valid_history, task_id="task-123")
     assert len(mock_agent.chat_history) == 3
-    assert mock_agent._history_injected is True
     assert mock_agent.task.id == "task-123"
 
 def test_validate_chat_history_no_system(mock_agent):
     history = [{"role": "user", "content": "Hello"}]
     mock_agent._run_init(task="test", chat_history=history)
-    # pre_run should add system prompt
-    # Since we can't easily run pre_run (async iterator), we check _run_init state
-    assert len(mock_agent.chat_history) == 1
-    assert mock_agent._history_injected is True
+    # _run_init should prepend system prompt
+    assert len(mock_agent.chat_history) == 2
 
 @pytest.mark.asyncio
 async def test_react_agent_history_injection_pre_run(mock_agent):
@@ -278,3 +275,42 @@ def test_validate_history_multiple_turns():
         {"role": "assistant", "content": "It is 4."}
     ]
     ku.validate_chat_history(history)
+
+
+@pytest.mark.asyncio
+async def test_codeact_agent_history_injection_no_system_msg():
+    """Test that CodeActAgent correctly handles injected history without a system message.
+    This was previously failing with a KeyError because pre_run() was using a format string
+    that didn't include 'authorized_imports'.
+    """
+    from kodeagent.kodeagent import CodeActAgent
+    agent = CodeActAgent(model_name='gpt-3.5-turbo')
+    injected_history = [
+        {'role': 'user', 'content': 'Previous interaction'}
+    ]
+
+    # This call should not raise KeyError
+    agent._run_init(task='New task', chat_history=injected_history)
+
+    # Verify system message is at index 0 and has authorized_imports formatted
+    assert agent.chat_history[0]['role'] == 'system'
+    content = agent.chat_history[0]['content']
+    assert '- datetime' in content
+    assert 'Previous interaction' in agent.chat_history[1]['content']
+
+
+def test_agent_get_system_prompt_content_none():
+    """Test get_system_prompt_content when system_prompt is None."""
+    from kodeagent.kodeagent import ReActAgent
+    agent = ReActAgent(model_name='gpt-3.5-turbo', system_prompt=None)
+    assert agent.get_system_prompt_content() == ''
+
+
+@pytest.mark.asyncio
+async def test_codeact_parse_text_response_no_thought():
+    """Test CodeAct parser with missing Thought (should raise ValueError)."""
+    from kodeagent.kodeagent import CodeActAgent
+    agent = CodeActAgent(name='test_codeact', model_name='gpt-3.5-turbo', run_env='host')
+    text_response = "Code: print('hello')"
+    with pytest.raises(ValueError, match="Could not extract 'Thought:' field"):
+        agent.parse_text_response(text_response)

--- a/tests/unit/test_history_injection.py
+++ b/tests/unit/test_history_injection.py
@@ -1,0 +1,280 @@
+import pytest
+from kodeagent.kodeagent import ReActAgent
+from kodeagent.fca import FunctionCallingAgent
+from kodeagent.models import ChatMessage
+
+@pytest.fixture
+def mock_agent():
+    return ReActAgent(model_name="gpt-4", name="TestAgent")
+
+@pytest.fixture
+def mock_fca():
+    return FunctionCallingAgent(model_name="gpt-4")
+
+def test_validate_chat_history_valid(mock_agent):
+    valid_history = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!", "tool_calls": None}
+    ]
+    # This should not raise
+    mock_agent._run_init(task="test", chat_history=valid_history, task_id="task-123")
+    assert len(mock_agent.chat_history) == 3
+    assert mock_agent._history_injected is True
+    assert mock_agent.task.id == "task-123"
+
+def test_validate_chat_history_no_system(mock_agent):
+    history = [{"role": "user", "content": "Hello"}]
+    mock_agent._run_init(task="test", chat_history=history)
+    # pre_run should add system prompt
+    # Since we can't easily run pre_run (async iterator), we check _run_init state
+    assert len(mock_agent.chat_history) == 1
+    assert mock_agent._history_injected is True
+
+@pytest.mark.asyncio
+async def test_react_agent_history_injection_pre_run(mock_agent):
+    history = [{"role": "user", "content": "Hello"}]
+    mock_agent._run_init(task="Resuming task", chat_history=history)
+    
+    # We need to mock planner to avoid LLM calls in pre_run
+    from unittest.mock import MagicMock
+    mock_agent.planner = MagicMock()
+    mock_agent.planner.get_formatted_plan.return_value = "Step 1: Test"
+    mock_agent.planner.plan = "test"
+    mock_agent.planner.create_plan = MagicMock(side_effect=lambda *args, **kwargs: None)
+    # create_plan is actually awaited in pre_run, so it must be an AsyncMock
+    from unittest.mock import AsyncMock
+    mock_agent.planner.create_plan = AsyncMock()
+    
+    responses = []
+    async for resp in mock_agent.pre_run():
+        responses.append(resp)
+        
+    # Check that system prompt was prepended
+    assert mock_agent.chat_history[0]["role"] == "system"
+    assert mock_agent.chat_history[1]["role"] == "user"
+    # Content is merged/converted to list by add_to_history
+    assert any("Hello" in item.get("text", "") for item in mock_agent.chat_history[1]["content"])
+    
+    # New task should be in the history as well
+    def has_text(content, search_str):
+        if isinstance(content, str):
+            return search_str in content
+        if isinstance(content, list):
+            return any(search_str in item.get("text", "") for item in content)
+        return False
+
+    assert any(has_text(m.get("content"), "New Task:\nResuming task") for m in mock_agent.chat_history)
+
+def test_validate_chat_history_invalid_role(mock_agent):
+    invalid_history = [{"role": "bad_role", "content": "Hello"}]
+    with pytest.raises(ValueError, match="role' must be one of"):
+        mock_agent._run_init(task="test", chat_history=invalid_history)
+
+def test_validate_chat_history_unresolved_tool_call(mock_agent):
+    invalid_history = [
+        {"role": "assistant", "tool_calls": [{"id": "1", "type": "function", "function": {"name": "test", "arguments": "{}"}}]}
+    ]
+    with pytest.raises(ValueError, match="unresolved tool call"):
+        mock_agent._run_init(task="test", chat_history=invalid_history)
+
+def test_fca_history_injection_valid(mock_fca):
+    valid_history = [{"role": "user", "content": "Hello"}]
+    # FCA _run_init is async
+    import asyncio
+    asyncio.run(mock_fca._run_init(task_desc="test", chat_history=valid_history, use_planning=False, task_id="fca-task"))
+    
+    assert mock_fca.chat_history[0]["role"] == "system"
+    assert mock_fca.chat_history[1]["role"] == "user"
+    assert mock_fca.task.id == "fca-task"
+    
+    def has_text(content, search_str):
+        if isinstance(content, str):
+            return search_str in content
+        if isinstance(content, list):
+            return any(search_str in item.get("text", "") for item in content)
+        return False
+
+    # FCA uses kutils.make_user_message which returns list content
+    assert has_text(mock_fca.chat_history[1]["content"], "Hello")
+    # FCA appends the new task message immediately in _run_init
+    assert has_text(mock_fca.chat_history[2]["content"], "## New Task:\ntest")
+
+@pytest.mark.asyncio
+async def test_react_agent_history_injection_with_system(mock_agent):
+    # History already has a system message
+    history = [
+        {"role": "system", "content": "Existing system message"},
+        {"role": "user", "content": "Hello"}
+    ]
+    mock_agent._run_init(task="New task", chat_history=history)
+    
+    from unittest.mock import MagicMock, AsyncMock
+    mock_agent.planner = MagicMock()
+    mock_agent.planner.get_formatted_plan.return_value = "Plan"
+    mock_agent.planner.create_plan = AsyncMock()
+    
+    async for _ in mock_agent.pre_run(): pass
+    
+    # System message should NOT be prepended again
+    assert mock_agent.chat_history[0]["content"] == "Existing system message"
+    assert mock_agent.chat_history[1]["role"] == "user"
+
+@pytest.mark.asyncio
+async def test_fca_history_injection_with_system(mock_fca):
+    # History already has a system message
+    history = [
+        {"role": "system", "content": "Existing system message"},
+        {"role": "user", "content": "Hello"}
+    ]
+    await mock_fca._run_init(task_desc="test", chat_history=history, use_planning=False)
+    
+    # System message should NOT be prepended again
+    assert mock_fca.chat_history[0]["content"] == "Existing system message"
+    assert mock_fca.chat_history[1]["role"] == "user"
+
+def test_mutual_exclusivity_react(mock_agent):
+    import asyncio
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        # We need to wrap the async generator to trigger the check if it were in the body,
+        # but here it's at the start of run()
+        gen = mock_agent.run(task="test", recurrent_mode=True, chat_history=[{"role": "user", "content": "hi"}])
+        asyncio.run(gen.__anext__())
+
+def test_mutual_exclusivity_fca(mock_fca):
+    import asyncio
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        gen = mock_fca.run(task="test", recurrent_mode=True, chat_history=[{"role": "user", "content": "hi"}])
+        asyncio.run(gen.__anext__())
+
+# Direct kutils.validate_chat_history tests for coverage
+from kodeagent import kutils as ku
+
+def test_validate_history_not_list():
+    with pytest.raises(ValueError, match="must be a list"):
+        ku.validate_chat_history("not a list")
+
+def test_validate_history_empty():
+    with pytest.raises(ValueError, match="must not be empty"):
+        ku.validate_chat_history([])
+
+def test_validate_history_msg_not_dict():
+    with pytest.raises(ValueError, match="must be a dict"):
+        ku.validate_chat_history(["not a dict"])
+
+def test_validate_history_invalid_role():
+    with pytest.raises(ValueError, match="role' must be one of"):
+        ku.validate_chat_history([{"role": "invalid"}])
+
+def test_validate_history_system_not_at_0():
+    with pytest.raises(ValueError, match="must be at index 0"):
+        ku.validate_chat_history([
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "sys"}
+        ])
+
+def test_validate_history_multiple_systems():
+    # This check is slightly redundant with "must be at index 0" but good to have
+    # because the loop continues. Actually, if there's one at 0 and one at 1,
+    # the index check for index 1 triggers first.
+    # To trigger "only one system message is allowed", we'd need to bypass idx!=0 check.
+    # Wait, the code says:
+    # if role == 'system':
+    #     if idx != 0: raise ValueError(...)
+    #     if system_seen_at is not None: raise ValueError(...)
+    # So idx!=0 ALWAYS triggers if it's not the first one.
+    pass
+
+def test_validate_history_system_none_content():
+    with pytest.raises(ValueError, match="must have a non-None 'content'"):
+        ku.validate_chat_history([{"role": "system", "content": None}])
+
+def test_validate_history_user_none_content():
+    with pytest.raises(ValueError, match="must have a non-None 'content'"):
+        ku.validate_chat_history([{"role": "user", "content": None}])
+
+def test_validate_history_assistant_empty():
+    with pytest.raises(ValueError, match="must have either 'content' or 'tool_calls'"):
+        ku.validate_chat_history([{"role": "assistant"}])
+
+def test_validate_history_assistant_invalid_tool_calls():
+    with pytest.raises(ValueError, match="'tool_calls' must be a list"):
+        ku.validate_chat_history([{"role": "assistant", "tool_calls": "not a list"}])
+
+def test_validate_history_tool_call_not_dict():
+    with pytest.raises(ValueError, match="must be a dict"):
+        ku.validate_chat_history([{"role": "assistant", "tool_calls": ["not a dict"]}])
+
+def test_validate_history_tool_call_missing_id():
+    with pytest.raises(ValueError, match="missing or empty 'id'"):
+        ku.validate_chat_history([{"role": "assistant", "tool_calls": [{"id": None}]}])
+
+def test_validate_history_tool_call_invalid_type():
+    with pytest.raises(ValueError, match="'type' must be 'function'"):
+        ku.validate_chat_history([{"role": "assistant", "tool_calls": [{"id": "1", "type": "not_fn"}]}])
+
+def test_validate_history_tool_call_function_not_dict():
+    with pytest.raises(ValueError, match="'function' must be a dict"):
+        ku.validate_chat_history([{"role": "assistant", "tool_calls": [{"id": "1", "type": "function", "function": "not a dict"}]}])
+
+def test_validate_history_tool_call_function_name_missing():
+    with pytest.raises(ValueError, match="'function.name' must be a non-empty string"):
+        ku.validate_chat_history([{"role": "assistant", "tool_calls": [{"id": "1", "type": "function", "function": {"name": ""}}]}])
+
+def test_validate_history_tool_call_function_args_not_str():
+    with pytest.raises(ValueError, match="'function.arguments' must be a string"):
+        ku.validate_chat_history([{"role": "assistant", "tool_calls": [{"id": "1", "type": "function", "function": {"name": "f", "arguments": {}}}]}])
+
+def test_validate_history_tool_call_unknown_tool_warning(caplog):
+    import logging
+    with caplog.at_level(logging.WARNING):
+        ku.validate_chat_history([
+            {"role": "assistant", "tool_calls": [{"id": "1", "type": "function", "function": {"name": "unknown", "arguments": "{}"}}]},
+            {"role": "tool", "tool_call_id": "1", "name": "unknown", "content": "res"}
+        ], tool_names={"known"})
+    assert "tool name 'unknown' not registered" in caplog.text
+
+def test_validate_history_tool_missing_id():
+    with pytest.raises(ValueError, match="missing or empty 'tool_call_id'"):
+        ku.validate_chat_history([{"role": "tool"}])
+
+def test_validate_history_tool_missing_name():
+    with pytest.raises(ValueError, match="missing or empty 'name'"):
+        ku.validate_chat_history([{"role": "tool", "tool_call_id": "1"}])
+
+def test_validate_history_tool_content_not_str():
+    with pytest.raises(ValueError, match="'content' must be a string"):
+        ku.validate_chat_history([{"role": "tool", "tool_call_id": "1", "name": "n", "content": None}])
+
+def test_validate_history_unresolved_tool_call_ids():
+    # Tests the backward walk and resolving IDs
+    with pytest.raises(ValueError, match="unresolved tool call"):
+        ku.validate_chat_history([
+            {"role": "assistant", "tool_calls": [{"id": "1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]}
+        ])
+    
+    # This should pass
+    ku.validate_chat_history([
+        {"role": "assistant", "tool_calls": [{"id": "1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "1", "name": "f", "content": "res"}
+    ])
+
+def test_validate_history_unknown_tool_call_id():
+    with pytest.raises(ValueError, match="refers to unknown tool_call_id"):
+        ku.validate_chat_history([
+            {"role": "tool", "tool_call_id": "ghost_id", "name": "f", "content": "res"}
+        ])
+
+def test_validate_history_multiple_turns():
+    # Valid interleaved history
+    history = [
+        {"role": "user", "content": "1+1?"},
+        {"role": "assistant", "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "name": "f", "content": "2"},
+        {"role": "assistant", "content": "It is 2."},
+        {"role": "user", "content": "And 2+2?"},
+        {"role": "assistant", "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "f", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c2", "name": "f", "content": "4"},
+        {"role": "assistant", "content": "It is 4."}
+    ]
+    ku.validate_chat_history(history)

--- a/tests/unit/test_kodeagent.py
+++ b/tests/unit/test_kodeagent.py
@@ -2112,8 +2112,8 @@ def test_agent_msg_idx_of_new_task():
     # Start new task
     agent._run_init('Second task')
 
-    # msg_idx should still be 0 (it's set in run(), not _run_init())
-    assert agent.msg_idx_of_new_task == 0
+    # msg_idx should be 1 (system prompt is added in _run_init())
+    assert agent.msg_idx_of_new_task == 1
     assert agent.task_output_files == []
 
 
@@ -2513,7 +2513,120 @@ def test_run_init_calls_cleanup(react_agent):
 
     # Verify old state was cleaned up
     assert react_agent.task.description == 'Task 2'
-    assert react_agent.msg_idx_of_new_task == 0
+    assert react_agent.msg_idx_of_new_task == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_record_thought_fallback(react_agent):
+    """Test _record_thought with malformed JSON that triggers text fallback."""
+    react_agent._run_init('Test task')
+
+    # Malformed JSON that JSON parser will fail on, but regex can handle
+    malformed_response = (
+        "Thought: This is a thought.\n"
+        "Action: calculator\n"
+        "Args: {\"expression\": \"2+2\"}"
+    )
+
+    # We need to mock _chat to return this malformed response
+    with patch.object(react_agent, '_chat', return_value=malformed_response):
+        # We need to use ReActChatMessage as the format class
+        from kodeagent.models import ReActChatMessage
+        msg = await react_agent._record_thought(ReActChatMessage)
+
+        assert msg is not None
+        assert msg.thought == 'This is a thought.'
+        assert msg.action == 'calculator'
+        assert msg.args == '{"expression": "2+2"}'
+        assert msg.role == 'assistant'
+
+
+@pytest.mark.asyncio
+async def test_act_with_json_stripping(react_agent):
+    """Test _act with tool args that need 'json' prefix stripping."""
+    react_agent._run_init('Test')
+
+    # Message with args starting with 'json'
+    msg = ReActChatMessage(
+        role='assistant',
+        thought='Stripping json',
+        action='calculator',
+        args='json {"expression": "2+2"}',
+        task_successful=False,
+        final_answer=None,
+    )
+    react_agent.add_to_history(msg)
+
+    responses = []
+    async for response in react_agent._act():
+        responses.append(response)
+
+    assert any('4' in str(r.get('value')) for r in responses)
+
+
+@pytest.mark.asyncio
+async def test_act_with_json_repair(react_agent):
+    """Test _act with malformed tool args that need repair."""
+    react_agent._run_init('Test')
+
+    # Malformed JSON (missing closing brace)
+    msg = ReActChatMessage(
+        role='assistant',
+        thought='Repairing json',
+        action='calculator',
+        args='{"expression": "2+2"',
+        task_successful=False,
+        final_answer=None,
+    )
+    react_agent.add_to_history(msg)
+
+    responses = []
+    async for response in react_agent._act():
+        responses.append(response)
+
+    assert any('4' in str(r.get('value')) for r in responses)
+
+
+def test_agent_normalize_content_multimodal():
+    """Test normalize_content with multimodal list input."""
+    from kodeagent.kodeagent import ReActAgent
+    agent = ReActAgent(model_name='gpt-3.5-turbo')
+    content = [
+        {'type': 'text', 'text': 'Hello '},
+        {'type': 'image_url', 'image_url': {'url': 'http://example.com/img.png'}}
+    ]
+    # Line 551: parts.append(str(item)) for non-text items
+    normalized = agent.normalize_content(content)
+    assert 'Hello' in normalized
+    assert 'image_url' in normalized
+
+
+def test_agent_add_to_history_merge_with_files():
+    """Test add_to_history merging consecutive user messages with files metadata."""
+    from kodeagent.kodeagent import ReActAgent
+    agent = ReActAgent(model_name='gpt-3.5-turbo')
+    agent.add_to_history({'role': 'user', 'content': 'First', 'files': ['a.txt']})
+    agent.add_to_history({'role': 'user', 'content': 'Second', 'files': ['b.txt']})
+
+    assert len(agent.chat_history) == 1
+    assert 'First' in str(agent.chat_history[0]['content'])
+    assert 'Second' in str(agent.chat_history[0]['content'])
+    # Line 486-489: prev_files = prev.get('files') or []
+    assert 'a.txt' in agent.chat_history[0]['files']
+    assert 'b.txt' in agent.chat_history[0]['files']
+
+    # Case for line 488: prev_files is not a list
+    agent.chat_history = [{'role': 'user', 'content': 'First', 'files': 'single.txt'}]
+    agent.add_to_history({'role': 'user', 'content': 'Second', 'files': ['list.txt']})
+    assert agent.chat_history[0]['files'] == ['single.txt', 'list.txt']
+
+
+def test_agent_normalize_content_dict():
+    """Test normalize_content with a dictionary input (line 554)."""
+    from kodeagent.kodeagent import ReActAgent
+    agent = ReActAgent(model_name='gpt-3.5-turbo')
+    content = {'key': 'value'}
+    assert agent.normalize_content(content) == "{'key': 'value'}"
 
 
 # ============================================================================


### PR DESCRIPTION
Closes #222.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume conversations by injecting OpenAI-compliant chat history as an alternative to recurrent mode.

* **Documentation**
  * Reorganized memory docs under a "Memory and State Management" section with clear guidance and examples for both Recurrent Mode and Chat History Injection; documents that the two options are mutually exclusive.

* **Examples**
  * Updated demo to showcase both recurrent-mode and chat-history resumption.

* **Tests**
  * Added comprehensive unit tests covering history validation and injection.

* **Chores**
  * Release version bumped to 0.14.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->