### PR TITLE
Upgrade Codecov action to v7

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -44,7 +44,7 @@ jobs:
         retention-days: 30
 
     - name: Coverage Report
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         # Provide the Codecov upload token from repo secrets
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Updated Codecov action to version 7 in the workflow to mitigate the GPG key access issue of Codecov (https://github.com/codecov/codecov-action/issues/1956)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->